### PR TITLE
Modernize and improve LTR390_DFR Driver

### DIFF
--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -115,8 +115,8 @@ public:
   //
   [[nodiscard]] uint32_t getALSData()
   {
-    uint32_t raw = readRegister(LTR390Reg::ALS_DATA_1) * 65536UL;
-    raw += readRegister(LTR390Reg::ALS_DATA_0);
+    uint32_t raw = static_cast<uint32_t>(readRegister(LTR390Reg::ALS_DATA_1)) << 16;
+    raw |= readRegister(LTR390Reg::ALS_DATA_0);
     return raw;
   }
 
@@ -131,8 +131,8 @@ public:
 
   [[nodiscard]] uint32_t getUVSData()
   {
-    uint32_t raw = readRegister(LTR390Reg::UVS_DATA_1) * 65536UL;
-    raw += readRegister(LTR390Reg::UVS_DATA_0);
+    uint32_t raw = static_cast<uint32_t>(readRegister(LTR390Reg::UVS_DATA_1)) << 16;
+    raw |= readRegister(LTR390Reg::UVS_DATA_0);
     return raw;
   }
 

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -44,14 +44,13 @@ namespace LTR390Reg
 class LTR390_DFR
 {
 public:
-  LTR390_DFR(TwoWire *wire = &Wire)
-  {
-    _address = 0x1C; //  Fixed 0x1C = 28 = DF_ROBOTICS
-    _wire = wire;
-    _gain = 3.0f; //  default
-    _time = 0.1f; //  default 18 bit, 100 ms.
-    _UVsensitivity = 1.0f;
-  }
+  explicit LTR390_DFR(TwoWire *wire = &Wire):
+    _address(0x1C), //  Fixed 0x1C = 28 = DF_ROBOTICS
+    _wire(wire),
+    _gain(3.0f), //  default
+    _time(0.1f), //  default 18 bit, 100 ms.
+    _UVsensitivity(1.0f)
+  {}
 
   bool begin()
   {

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -149,7 +149,7 @@ public:
   //
   //  MEASUREMENT CONFIGURATION
   //
-  uint8_t setGain(uint8_t gain = 1)
+  [[nodiscard]] uint8_t setGain(uint8_t gain = 1)
   {
     constexpr uint8_t gainTable[] = {1, 3, 6, 9, 18};    
     if (gain > 4)
@@ -246,7 +246,7 @@ public:
     //
     //  MAIN STATUS
     //
-    uint8_t getStatus()
+    [[nodiscard]] uint8_t getStatus()
     {
       uint8_t reg = readRegister(LTR390Reg::MAIN_STATUS);  ? no such register.
       return reg & 0x38;
@@ -257,22 +257,22 @@ public:
     //
     //  INTERRUPT
     //
-    int setInterruptConfig(uint8_t value = 0x10)
+    [[nodiscard]] int setInterruptConfig(uint8_t value = 0x10)
     {
       return writeRegister(LTR390Reg::INT_CFG, value);
     }
 
-    uint8_t getInterruptConfig()
+    [[nodiscard]] uint8_t getInterruptConfig()
     {
       return readRegister(LTR390Reg::INT_CFG);
     }
 
-    int setInterruptPersist(uint8_t value = 0x00)
+    [[nodiscard]] int setInterruptPersist(uint8_t value = 0x00)
     {
       return writeRegister(LTR390Reg::INT_PST, value);
     }
 
-    uint8_t getInterruptPersist()
+    [[nodiscard]] uint8_t getInterruptPersist()
     {
       return readRegister(LTR390Reg::INT_PST);
     }
@@ -290,7 +290,7 @@ public:
       writeRegister(LTR390Reg::ALS_UVS_THRES_UP_1, value >> 16);
     }
 
-    uint32_t getHighThreshold()
+    [[nodiscard]] uint32_t getHighThreshold()
     {
       uint32_t value = readRegister(LTR390Reg::ALS_UVS_THRES_UP_1) << 16;
       value += readRegister(LTR390Reg::ALS_UVS_THRES_UP_0);
@@ -303,7 +303,7 @@ public:
       writeRegister(LTR390Reg::ALS_UVS_THRES_LOW_1, value >> 16);
     }
 
-    uint32_t getLowThreshold()
+    [[nodiscard]] uint32_t getLowThreshold()
     {
       uint32_t value = readRegister(LTR390Reg::ALS_UVS_THRES_LOW_1) << 16;
       value += readRegister(LTR390Reg::ALS_UVS_THRES_LOW_0);

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -52,18 +52,18 @@ public:
     _UVsensitivity(1.0f)
   {}
 
-  bool begin()
+  [[nodiscard]] bool begin()
   {
     return isConnected();
   }
 
-  bool isConnected()
+  [[nodiscard]] bool isConnected()
   {
     _wire->beginTransmission(_address);
     return (_wire->endTransmission() == 0);
   }
 
-  uint8_t getAddress()
+  [[nodiscard]] uint8_t getAddress()
   {
     return _address;
   }
@@ -86,7 +86,7 @@ public:
     writeRegister(LTR390Reg::MAIN_CTRL, raw);
   }
 
-  uint8_t reset()
+  [[nodiscard]] uint8_t reset()
   {
     writeRegister(LTR390Reg::MAIN_CTRL, 0x10);
     delay(100);
@@ -97,13 +97,13 @@ public:
   //
   //  PART_ID
   //
-  uint8_t getPartID()
+  [[nodiscard]] uint8_t getPartID()
   {
     uint8_t reg = readRegister(LTR390Reg::PART_ID);
     return reg >> 4;
   }
 
-  uint8_t getRevisionID()
+  [[nodiscard]] uint8_t getRevisionID()
   {
     uint8_t reg = readRegister(LTR390Reg::PART_ID);
     return reg & 0x0F;
@@ -113,7 +113,7 @@ public:
   //
   //  GET DATA
   //
-  uint32_t getALSData()
+  [[nodiscard]] uint32_t getALSData()
   {
     uint32_t raw = readRegister(LTR390Reg::ALS_DATA_1) * 65536UL;
     raw += readRegister(LTR390Reg::ALS_DATA_0);
@@ -121,7 +121,7 @@ public:
   }
 
   //  page 22 datasheet
-  float getLux(float wfac = 1)
+  [[nodiscard]] float getLux(float wfac = 1)
   {
     float lux = 0.6f * getALSData() / (_gain * _time);
     if (wfac > 1)
@@ -129,7 +129,7 @@ public:
     return lux;
   }
 
-  uint32_t getUVSData()
+  [[nodiscard]] uint32_t getUVSData()
   {
     uint32_t raw = readRegister(LTR390Reg::UVS_DATA_1) * 65536UL;
     raw += readRegister(LTR390Reg::UVS_DATA_0);
@@ -137,7 +137,7 @@ public:
   }
 
   //  page 22 datasheet
-  float getUVI(float wfac = 1.0f)
+  [[nodiscard]] float getUVI(float wfac = 1.0f)
   {
     float uvi = getUVSData() / _UVsensitivity;
     if (wfac > 1.0f)
@@ -167,7 +167,7 @@ public:
     return value;
   }
 
-  uint8_t getGain()
+  [[nodiscard]] uint8_t getGain()
   {
     uint16_t reg = readRegister(LTR390Reg::GAIN);
     return reg & 0x07;
@@ -175,7 +175,7 @@ public:
 
   //  resolution = 0..5  See datasheet P14.
   //        time = 0..7  See datasheet P14.
-  bool setMeasurement(uint8_t resolution, uint8_t time)
+  [[nodiscard]] bool setMeasurement(uint8_t resolution, uint8_t time)
   {
     if (resolution > 5)
       return false;
@@ -201,19 +201,19 @@ public:
     return true;
   }
 
-  uint8_t getResolution()
+  [[nodiscard]] uint8_t getResolution()
   {
     uint16_t reg = readRegister(LTR390Reg::ALS_UVS_MEAS_RATE);
     return (reg >> 4) & 0x07;
   }
 
-  uint8_t getTime()
+  [[nodiscard]] uint8_t getTime()
   {
     uint16_t reg = readRegister(LTR390Reg::ALS_UVS_MEAS_RATE);
     return reg & 0x07;
   }
 
-  bool setUVsensitivity(float s)
+  [[nodiscard]] bool setUVsensitivity(float s)
   {
     if ((s <= 0.0f) || (s > 1.0f))
       return false;
@@ -221,7 +221,7 @@ public:
     return true;
   }
 
-  float getUVsensitivity()
+  [[nodiscard]] float getUVsensitivity()
   {
     return _UVsensitivity;
   }
@@ -324,7 +324,7 @@ public:
   //
   //  PRIVATE
   //
-  int writeRegister(uint8_t reg, uint16_t value)
+  [[nodiscard]] int writeRegister(uint8_t reg, uint16_t value)
   {
     _wire->beginTransmission(_address);
     _wire->write(reg);
@@ -340,7 +340,7 @@ public:
     return n;
   }
 
-  uint16_t readRegister(uint8_t reg)
+  [[nodiscard]] uint16_t readRegister(uint8_t reg)
   {
     _wire->beginTransmission(_address);
     _wire->write(reg);

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -10,7 +10,7 @@
 #include <Arduino.h>
 #include <Wire.h>
 
-const __FlashStringHelper *LTR390_DFR_LIB_VERSION = F("0.1.2");
+#define LTR390_DFR_LIB_VERSION (F("0.1.2"))
 
 //  LTR390 ERROR CODES
 constexpr uint8_t LTR390_OK = 0x00;

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -7,50 +7,49 @@
 // PURPOSE: Arduino library for the I2C LTR390 UV sensor (DF Robotics edition).
 //     URL: https://github.com/RobTillaart/LTR390_DFR
 
+#include <Arduino.h>
+#include <Wire.h>
 
-#include "Arduino.h"
-#include "Wire.h"
-
-
-#define LTR390_DFR_LIB_VERSION         (F("0.1.2"))
+constexpr __FlashStringHelper *LTR390_DFR_LIB_VERSION = F("0.1.2");
 
 //  LTR390 ERROR CODES
-#define LTR390_OK                       0x00
-
+constexpr uint8_t LTR390_OK = 0x00;
 
 //  DF_ROBOTICS LTR390 REGISTERS (16 bits)
-#define LTR390_PID                      0x00
-#define LTR390_ADDRESS                  0x02
-#define LTR390_FIRMWARE                 0x05
-#define LTR390_PART_ID                  0x06
+namespace LTR390Reg
+{
+  constexpr uint8_t PID      = 0x00;
+  constexpr uint8_t ADDRESS  = 0x02;
+  constexpr uint8_t FIRMWARE = 0x05;
+  constexpr uint8_t PART_ID  = 0x06;
 
-#define LTR390_ALS_DATA_0               0x07
-#define LTR390_ALS_DATA_1               0x08
-#define LTR390_UVS_DATA_0               0x09
-#define LTR390_UVS_DATA_1               0x0A
+  constexpr uint8_t ALS_DATA_0 = 0x07;
+  constexpr uint8_t ALS_DATA_1 = 0x08;
+  constexpr uint8_t UVS_DATA_0 = 0x09;
+  constexpr uint8_t UVS_DATA_1 = 0x0A;
 
-#define LTR390_GAIN                     0x0B
-#define LTR390_INT_CONFIG               0x0C
+  constexpr uint8_t GAIN       = 0x0B;
+  constexpr uint8_t INT_CONFIG = 0x0C;
 
-#define LTR390_ALS_UVS_THRES_UP_0       0x0D
-#define LTR390_ALS_UVS_THRES_UP_1       0x0E
-#define LTR390_ALS_UVS_THRES_LOW_0      0x0F
-#define LTR390_ALS_UVS_THRES_LOW_1      0x10
-#define LTR390_ALS_UVS_THRES_VAR_DATA   0x11
+  constexpr uint8_t ALS_UVS_THRES_UP_0   = 0x0D;
+  constexpr uint8_t ALS_UVS_THRES_UP_1   = 0x0E;
+  constexpr uint8_t ALS_UVS_THRES_LOW_0  = 0x0F;
+  constexpr uint8_t ALS_UVS_THRES_LOW_1  = 0x10;
+  constexpr uint8_t ALS_UVS_THRES_VAR_DATA = 0x11;
 
-#define LTR390_ALS_UVS_MEAS_RATE        0x12
-#define LTR390_MAIN_CTRL                0x13
-
+  constexpr uint8_t ALS_UVS_MEAS_RATE = 0x12;
+  constexpr uint8_t MAIN_CTRL = 0x13;
+}
 
 class LTR390_DFR
 {
 public:
   LTR390_DFR(TwoWire *wire = &Wire)
   {
-    _address = 0x1C;  //  Fixed 0x1C = 28 = DF_ROBOTICS
+    _address = 0x1C; //  Fixed 0x1C = 28 = DF_ROBOTICS
     _wire = wire;
-    _gain = 3.0f;  //  default
-    _time = 0.1f;  //  default 18 bit, 100 ms.
+    _gain = 3.0f; //  default
+    _time = 0.1f; //  default 18 bit, 100 ms.
     _UVsensitivity = 1.0f;
   }
 
@@ -70,32 +69,30 @@ public:
     return _address;
   }
 
-
   //////////////////////////////////////////////
   //
   //  MAIN CONTROL
   //
   void setALSMode()
   {
-    uint8_t raw = readRegister(LTR390_MAIN_CTRL);
+    uint8_t raw = readRegister(LTR390Reg::MAIN_CTRL);
     raw &= ~0x08;
-    writeRegister(LTR390_MAIN_CTRL, raw);
+    writeRegister(LTR390Reg::MAIN_CTRL, raw);
   }
 
   void setUVSMode()
   {
-    uint8_t raw = readRegister(LTR390_MAIN_CTRL);
+    uint8_t raw = readRegister(LTR390Reg::MAIN_CTRL);
     raw |= 0x08;
-    writeRegister(LTR390_MAIN_CTRL, raw);
+    writeRegister(LTR390Reg::MAIN_CTRL, raw);
   }
 
   uint8_t reset()
   {
-    writeRegister(LTR390_MAIN_CTRL, 0x10);
+    writeRegister(LTR390Reg::MAIN_CTRL, 0x10);
     delay(100);
-    return readRegister(LTR390_MAIN_CTRL);
+    return readRegister(LTR390Reg::MAIN_CTRL);
   }
-
 
   //////////////////////////////////////////////
   //
@@ -103,16 +100,15 @@ public:
   //
   uint8_t getPartID()
   {
-    uint8_t reg = readRegister(LTR390_PART_ID);
+    uint8_t reg = readRegister(LTR390Reg::PART_ID);
     return reg >> 4;
   }
 
   uint8_t getRevisionID()
   {
-    uint8_t reg = readRegister(LTR390_PART_ID);
+    uint8_t reg = readRegister(LTR390Reg::PART_ID);
     return reg & 0x0F;
   }
-
 
   //////////////////////////////////////////////
   //
@@ -120,23 +116,24 @@ public:
   //
   uint32_t getALSData()
   {
-    uint32_t raw = readRegister(LTR390_ALS_DATA_1) * 65536UL;
-    raw += readRegister(LTR390_ALS_DATA_0);
+    uint32_t raw = readRegister(LTR390Reg::ALS_DATA_1) * 65536UL;
+    raw += readRegister(LTR390Reg::ALS_DATA_0);
     return raw;
   }
 
   //  page 22 datasheet
   float getLux(float wfac = 1)
   {
-    float lux = 0.6f * getALSData() /( _gain * _time);
-    if (wfac > 1) lux *= wfac;
+    float lux = 0.6f * getALSData() / (_gain * _time);
+    if (wfac > 1)
+      lux *= wfac;
     return lux;
   }
 
   uint32_t getUVSData()
   {
-    uint32_t raw = readRegister(LTR390_UVS_DATA_1) * 65536UL;
-    raw += readRegister(LTR390_UVS_DATA_0);
+    uint32_t raw = readRegister(LTR390Reg::UVS_DATA_1) * 65536UL;
+    raw += readRegister(LTR390Reg::UVS_DATA_0);
     return raw;
   }
 
@@ -144,31 +141,36 @@ public:
   float getUVI(float wfac = 1.0f)
   {
     float uvi = getUVSData() / _UVsensitivity;
-    if (wfac > 1.0f) uvi *= wfac;
+    if (wfac > 1.0f)
+      uvi *= wfac;
     return uvi;
   }
-
 
   //////////////////////////////////////////////
   //
   //  MEASUREMENT CONFIGURATION
   //
-  uint8_t setGain(uint8_t gain = 1)  //  0..4
+  uint8_t setGain(uint8_t gain = 1) //  0..4
   {
     uint16_t value = gain;
-    if (value > 4) value = 4;
-    writeRegister(LTR390_GAIN, value);
+    if (value > 4)
+      value = 4;
+    writeRegister(LTR390Reg::GAIN, value);
     _gain = 1;
-    if      (value == 1) _gain = 3;
-    else if (value == 2) _gain = 6;
-    else if (value == 3) _gain = 9;
-    else if (value == 4) _gain = 18;
+    if (value == 1)
+      _gain = 3;
+    else if (value == 2)
+      _gain = 6;
+    else if (value == 3)
+      _gain = 9;
+    else if (value == 4)
+      _gain = 18;
     return value;
   }
 
   uint8_t getGain()
   {
-    uint16_t reg = readRegister(LTR390_GAIN);
+    uint16_t reg = readRegister(LTR390Reg::GAIN);
     return reg & 0x07;
   }
 
@@ -176,37 +178,46 @@ public:
   //        time = 0..7  See datasheet P14.
   bool setMeasurement(uint8_t resolution, uint8_t time)
   {
-    if (resolution > 5) return false;
-    if (time > 7 ) return false;
+    if (resolution > 5)
+      return false;
+    if (time > 7)
+      return false;
 
     uint16_t value = (resolution << 4) | time;
-    writeRegister(LTR390_ALS_UVS_MEAS_RATE, value);
+    writeRegister(LTR390Reg::ALS_UVS_MEAS_RATE, value);
 
-    _time = 2.000;  // time = 6 0r 7
-    if (time == 0) _time = 0.025f;
-    if (time == 1) _time = 0.050f;
-    if (time == 2) _time = 0.100f;
-    if (time == 3) _time = 0.200f;
-    if (time == 4) _time = 0.500f;
-    if (time == 5) _time = 1.000f;
+    _time = 2.000; // time = 6 0r 7
+    if (time == 0)
+      _time = 0.025f;
+    if (time == 1)
+      _time = 0.050f;
+    if (time == 2)
+      _time = 0.100f;
+    if (time == 3)
+      _time = 0.200f;
+    if (time == 4)
+      _time = 0.500f;
+    if (time == 5)
+      _time = 1.000f;
     return true;
   }
 
   uint8_t getResolution()
   {
-    uint16_t reg = readRegister(LTR390_ALS_UVS_MEAS_RATE);
+    uint16_t reg = readRegister(LTR390Reg::ALS_UVS_MEAS_RATE);
     return (reg >> 4) & 0x07;
   }
 
   uint8_t getTime()
   {
-    uint16_t reg = readRegister(LTR390_ALS_UVS_MEAS_RATE);
+    uint16_t reg = readRegister(LTR390Reg::ALS_UVS_MEAS_RATE);
     return reg & 0x07;
   }
 
   bool setUVsensitivity(float s)
   {
-    if ((s <= 0.0f) || (s > 1.0f))return false;
+    if ((s <= 0.0f) || (s > 1.0f))
+      return false;
     _UVsensitivity = s;
     return true;
   }
@@ -216,102 +227,99 @@ public:
     return _UVsensitivity;
   }
 
-
-//
-//  Code below this line is not tested yet.
-//  Use carefully, feel free to experiment.
-//  Please let me know if it works or not.
-//
-
-/*
-  void enable()
-  {
-    uint8_t raw = readRegister(LTR390_MAIN_CTRL);
-    raw != 0x02;
-    writeRegister(LTR390_MAIN_CTRL, raw);
-  }
-
-  void disable()
-  {
-    uint8_t raw = readRegister(LTR390_MAIN_CTRL);
-    raw &= ~0x02;
-    writeRegister(LTR390_MAIN_CTRL, raw);
-  }
-*/
-
-
-/*
-  //////////////////////////////////////////////
   //
-  //  MAIN STATUS
+  //  Code below this line is not tested yet.
+  //  Use carefully, feel free to experiment.
+  //  Please let me know if it works or not.
   //
-  uint8_t getStatus()
-  {
-    uint8_t reg = readRegister(LTR390_MAIN_STATUS);  ? no such register.
-    return reg & 0x38;
-  }
+
+  /*
+    void enable()
+    {
+      uint8_t raw = readRegister(LTR390Reg::MAIN_CTRL);
+      raw != 0x02;
+      writeRegister(LTR390Reg::MAIN_CTRL, raw);
+    }
+
+    void disable()
+    {
+      uint8_t raw = readRegister(LTR390Reg::MAIN_CTRL);
+      raw &= ~0x02;
+      writeRegister(LTR390Reg::MAIN_CTRL, raw);
+    }
+  */
+
+  /*
+    //////////////////////////////////////////////
+    //
+    //  MAIN STATUS
+    //
+    uint8_t getStatus()
+    {
+      uint8_t reg = readRegister(LTR390Reg::MAIN_STATUS);  ? no such register.
+      return reg & 0x38;
+    }
 
 
-  //////////////////////////////////////////////
-  //
-  //  INTERRUPT
-  //
-  int setInterruptConfig(uint8_t value = 0x10)
-  {
-    return writeRegister(LTR390_INT_CFG, value);
-  }
+    //////////////////////////////////////////////
+    //
+    //  INTERRUPT
+    //
+    int setInterruptConfig(uint8_t value = 0x10)
+    {
+      return writeRegister(LTR390Reg::INT_CFG, value);
+    }
 
-  uint8_t getInterruptConfig()
-  {
-    return readRegister(LTR390_INT_CFG);
-  }
+    uint8_t getInterruptConfig()
+    {
+      return readRegister(LTR390Reg::INT_CFG);
+    }
 
-  int setInterruptPersist(uint8_t value = 0x00)
-  {
-    return writeRegister(LTR390_INT_PST, value);
-  }
+    int setInterruptPersist(uint8_t value = 0x00)
+    {
+      return writeRegister(LTR390Reg::INT_PST, value);
+    }
 
-  uint8_t getInterruptPersist()
-  {
-    return readRegister(LTR390_INT_PST);
-  }
+    uint8_t getInterruptPersist()
+    {
+      return readRegister(LTR390Reg::INT_PST);
+    }
 
 
-  //////////////////////////////////////////////
-  //
-  //  THRESHOLD
-  //
-  //  note registers are 16 bit.
-  //
-  void setHighThreshold(uint32_t value = 0x000FFFFF)
-  {
-    writeRegister(LTR390_ALS_UVS_THRES_UP_0, value & 0xFFFF);
-    writeRegister(LTR390_ALS_UVS_THRES_UP_1, value >> 16);
-  }
+    //////////////////////////////////////////////
+    //
+    //  THRESHOLD
+    //
+    //  note registers are 16 bit.
+    //
+    void setHighThreshold(uint32_t value = 0x000FFFFF)
+    {
+      writeRegister(LTR390Reg::ALS_UVS_THRES_UP_0, value & 0xFFFF);
+      writeRegister(LTR390Reg::ALS_UVS_THRES_UP_1, value >> 16);
+    }
 
-  uint32_t getHighThreshold()
-  {
-    uint32_t value = readRegister(LTR390_ALS_UVS_THRES_UP_1) << 16;
-    value += readRegister(LTR390_ALS_UVS_THRES_UP_0);
-    return value;
-  }
+    uint32_t getHighThreshold()
+    {
+      uint32_t value = readRegister(LTR390Reg::ALS_UVS_THRES_UP_1) << 16;
+      value += readRegister(LTR390Reg::ALS_UVS_THRES_UP_0);
+      return value;
+    }
 
-  void setLowThreshold(uint32_t value = 0)
-  {
-    writeRegister(LTR390_ALS_UVS_THRES_LOW_0, value & 0xFFFF);
-    writeRegister(LTR390_ALS_UVS_THRES_LOW_1, value >> 16);
-  }
+    void setLowThreshold(uint32_t value = 0)
+    {
+      writeRegister(LTR390Reg::ALS_UVS_THRES_LOW_0, value & 0xFFFF);
+      writeRegister(LTR390Reg::ALS_UVS_THRES_LOW_1, value >> 16);
+    }
 
-  uint32_t getLowThreshold()
-  {
-    uint32_t value = readRegister(LTR390_ALS_UVS_THRES_LOW_1) << 16;
-    value += readRegister(LTR390_ALS_UVS_THRES_LOW_0);
-    return value;
-  }
-*/
+    uint32_t getLowThreshold()
+    {
+      uint32_t value = readRegister(LTR390Reg::ALS_UVS_THRES_LOW_1) << 16;
+      value += readRegister(LTR390Reg::ALS_UVS_THRES_LOW_0);
+      return value;
+    }
+  */
 
-//  END OF PUBLIC PART
-
+  //  END OF PUBLIC PART
 
   //////////////////////////////////////////////
   //
@@ -326,13 +334,12 @@ public:
     int n = _wire->endTransmission();
     if (n != 0)
     {
-      //  _error = LTR390_I2C_ERROR;
+      //  _error = LTR390Reg::I2C_ERROR;
       //  Serial.print("write:\t");
       //  Serial.println(n);
     }
     return n;
   }
-
 
   uint16_t readRegister(uint8_t reg)
   {
@@ -341,7 +348,7 @@ public:
     int n = _wire->endTransmission();
     if (n != 0)
     {
-      //  _error = LTR390_I2C_ERROR;
+      //  _error = LTR390Reg::I2C_ERROR;
       //  Serial.print("read:\t");
       //  Serial.println(n);
       return n;
@@ -358,17 +365,14 @@ public:
     return data + _wire->read() * 256;
   }
 
-
 private:
-  TwoWire * _wire;
+  TwoWire *_wire;
   uint8_t _address;
 
   //  for LUX math
-  float   _gain;
-  float   _time;
-  float   _UVsensitivity;
+  float _gain;
+  float _time;
+  float _UVsensitivity;
 };
 
-
 //  -- END OF FILE --
-

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -45,8 +45,8 @@ class LTR390_DFR
 {
 public:
   explicit LTR390_DFR(TwoWire *wire = &Wire):
-    _address(0x1C), //  Fixed 0x1C = 28 = DF_ROBOTICS
     _wire(wire),
+    _address(0x1C), //  Fixed 0x1C = 28 = DF_ROBOTICS
     _gain(3.0f), //  default
     _time(0.1f), //  default 18 bit, 100 ms.
     _UVsensitivity(1.0f)

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -10,7 +10,7 @@
 #include <Arduino.h>
 #include <Wire.h>
 
-constexpr __FlashStringHelper *LTR390_DFR_LIB_VERSION = F("0.1.2");
+const __FlashStringHelper *LTR390_DFR_LIB_VERSION = F("0.1.2");
 
 //  LTR390 ERROR CODES
 constexpr uint8_t LTR390_OK = 0x00;

--- a/LTR390_DFR.h
+++ b/LTR390_DFR.h
@@ -131,8 +131,8 @@ public:
 
   [[nodiscard]] uint32_t getUVSData()
   {
-    uint32_t raw = static_cast<uint32_t>(readRegister(LTR390Reg::UVS_DATA_1)) << 16;
-    raw |= readRegister(LTR390Reg::UVS_DATA_0);
+    uint32_t raw = readRegister(LTR390Reg::UVS_DATA_1) * 65536UL;
+    raw += readRegister(LTR390Reg::UVS_DATA_0);
     return raw;
   }
 
@@ -149,22 +149,15 @@ public:
   //
   //  MEASUREMENT CONFIGURATION
   //
-  uint8_t setGain(uint8_t gain = 1) //  0..4
+  uint8_t setGain(uint8_t gain = 1)
   {
-    uint16_t value = gain;
-    if (value > 4)
-      value = 4;
-    writeRegister(LTR390Reg::GAIN, value);
-    _gain = 1;
-    if (value == 1)
-      _gain = 3;
-    else if (value == 2)
-      _gain = 6;
-    else if (value == 3)
-      _gain = 9;
-    else if (value == 4)
-      _gain = 18;
-    return value;
+    constexpr uint8_t gainTable[] = {1, 3, 6, 9, 18};    
+    if (gain > 4)
+      gain = 4;
+
+    writeRegister(LTR390Reg::GAIN, gain);
+    _gain = gainTable[gain];
+    return gain;
   }
 
   [[nodiscard]] uint8_t getGain()


### PR DESCRIPTION
### Summary of Changes

-  Replace `#define` macros with typed `constexpr` and group registers into a namespace
-  Modernize constructor using a member initializer list
-  Add `[[nodiscard]]` to critical functions
-  Fix potential overflow in ALS/UVS 32‑bit data reconstruction
-  Replace if/else cascade with a `constexpr` lookup table

### Important Note for Arduino IDE 1.x\2.x Users

Arduino IDE disables compiler warnings by default.
To benefit from the [[nodiscard]] improvements and detect ignored return values, users must manually enable warnings:

> Arduino IDE > File > Preferences > Compiler warnings > default (at least)